### PR TITLE
Move MicroCeph setup script

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,9 +13,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo apt update
-          sudo apt install -y restic ceph-common libcephfs-dev librbd-dev librados-dev
-          sudo snap install microceph
+          scripts/setup.sh
 
       - uses: actions/setup-go@v5
         with:
@@ -25,22 +23,6 @@ jobs:
         run: |
           go build
 
-      - name: Start MicroCeph cluster
-        run: |
-          sudo microceph cluster bootstrap
-          sudo microceph disk add loop,4G,3
-          sudo microceph status
-
-      - name: Set up global Ceph config
-        run: |
-          sudo cp /var/snap/microceph/current/conf/ceph.conf /etc/ceph/ceph.conf
-          sudo cp /var/snap/microceph/current/conf/ceph.client.admin.keyring /etc/ceph/ceph.client.admin.keyring
-          sudo cp /var/snap/microceph/current/conf/ceph.keyring /etc/ceph/ceph.keyring
-          sudo chmod 644 /etc/ceph/ceph.conf /etc/ceph/ceph.client.admin.keyring /etc/ceph/ceph.keyring
-
-      - name: Create Ceph test pool
-        run: |
-          sudo ceph osd pool create restic
 
       - name: Test
         run: |

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+sudo apt update
+sudo apt install --yes restic ceph-common libcephfs-dev librbd-dev librados-dev
+sudo snap install microceph
+
+sudo microceph cluster bootstrap
+sudo microceph disk add loop,4G,3
+sudo microceph status
+
+sudo microceph.ceph osd pool create restic
+
+sudo cp /var/snap/microceph/current/conf/ceph.conf /etc/ceph/ceph.conf
+sudo cp /var/snap/microceph/current/conf/ceph.client.admin.keyring /etc/ceph/ceph.client.admin.keyring
+sudo cp /var/snap/microceph/current/conf/ceph.keyring /etc/ceph/ceph.keyring
+sudo chmod 644 /etc/ceph/ceph.conf /etc/ceph/ceph.client.admin.keyring /etc/ceph/ceph.keyring


### PR DESCRIPTION
## Summary
- create a reusable `scripts/setup.sh`
- call the new script from the Go workflow with a multiline `run` block
- create the test pool before copying Ceph configs

## Testing
- `bash scripts/setup.sh` *(fails: `snap: command not found`)*
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_685b186b959c8326be073b41d16f73e8