### PR TITLE
Ensure snapd is installed in setup

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,8 +5,14 @@ set -o nounset
 set -o pipefail
 set -o xtrace
 
-sudo apt update
-sudo apt install --yes restic ceph-common libcephfs-dev librbd-dev librados-dev
+sudo apt-get update
+sudo apt-get install --yes \
+	restic \
+	ceph-common \
+	libcephfs-dev \
+	librbd-dev \
+	librados-dev \
+	snapd
 sudo snap install microceph
 
 sudo microceph cluster bootstrap


### PR DESCRIPTION
## Summary
- format `scripts/setup.sh` with `shfmt`
- run `shellcheck` to validate script
- script installs `snapd` for snap support

## Testing
- `shellcheck scripts/setup.sh`
- `shfmt -d scripts/setup.sh`
- `go test ./...` *(fails: missing ceph headers)*


------
https://chatgpt.com/codex/tasks/task_e_685b364152b08326a1b6f7a2c20f71c6