### PR TITLE
Improve AGENTS.md instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,13 @@ This project is written in Go and uses Go modules for dependency management. The
 ## Setup
 
 1. Install Go 1.24 or later.
-2. Download dependencies with:
+2. Install Restic by running the helper script (requires sudo if installing to a system path). The script installs the required Restic version, which may be newer than the one provided by apt:
+
+```sh
+./scripts/install-restic.sh /usr/local/bin
+```
+
+3. Download dependencies with:
 
 ```sh
 go mod download
@@ -18,8 +24,10 @@ installed. On Debian or Ubuntu systems you can install them with:
 
 ```sh
 sudo apt-get update
-sudo apt-get install ceph librados-dev restic
+sudo apt-get install ceph librados-dev
 ```
+
+> **Note:** Do not install Restic from apt; the repository version may be too old. Always use `scripts/install-restic.sh` to ensure the correct release is available.
 
 Run all tests with:
 

--- a/scripts/install-restic.sh
+++ b/scripts/install-restic.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o xtrace
+
+RESTIC_VERSION="${RESTIC_VERSION:-0.18.1}"
+
+if [[ $# -ne 1 ]]; then
+  printf 'Usage: %s <target-directory>\n' "$0" >&2
+  exit 1
+fi
+
+target="$1"
+
+mkdir --parents "${target}"
+
+curl --fail --location --show-error --silent \
+  "https://github.com/restic/restic/releases/download/v${RESTIC_VERSION}/restic_${RESTIC_VERSION}_linux_amd64.bz2" \
+  --output "${target}/restic_${RESTIC_VERSION}_linux_amd64.bz2"
+
+bunzip2 "${target}/restic_${RESTIC_VERSION}_linux_amd64.bz2"
+chmod +x "${target}/restic_${RESTIC_VERSION}_linux_amd64"
+install --mode=0755 "${target}/restic_${RESTIC_VERSION}_linux_amd64" "${target}/restic"


### PR DESCRIPTION
## Summary
- rename the helper directory to `scripts/` to align with repository conventions
- update agent instructions to point at the renamed installer and clarify that apt may provide an older Restic release

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddc268eab4832681b7ee7f90d51aac