### PR TITLE
Return 404 when Ceph pool is missing

### DIFF
--- a/testdata/restic-init-bad-pool.txtar
+++ b/testdata/restic-init-bad-pool.txtar
@@ -5,8 +5,10 @@ cmp stderr err.txt
 
 -- out.txt --
 -- err.txt --
-rclone: error: pool 'bad' does not exist: rados: ret=-2, No such file or directory
-Fatal: create repository at rclone: failed: Fatal: unable to open repository at rclone:: error talking HTTP to rclone: exit status 1
+rclone: HEAD /config
+rclone: POST /?create=true
+rclone: pool check failed: pool 'bad' does not exist: rados: ret=-2, No such file or directory
+Fatal: create repository at rclone: failed: Fatal: unable to open repository at rclone:: unexpected HTTP response (404): 404 Not Found
 
 -- password.txt --
 secret


### PR DESCRIPTION
## Summary
- defer Ceph pool validation from startup into the request handling path
- return HTTP 404 with a descriptive message when the configured pool is absent
- update the restic init bad pool test expectation for the new error output

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ddc80e968083268f13047b3a691def