### PR TITLE
Prevent object overwrites with explicit existence check

### DIFF
--- a/main.go
+++ b/main.go
@@ -682,6 +682,14 @@ func createRadosObject(w http.ResponseWriter, r *http.Request, ioctx *rados.IOCo
 		}
 	}
 
+	_, err = ioctx.Stat(object)
+	if err == nil {
+		return errObjectExists
+	}
+	if !errors.Is(err, rados.ErrNotFound) {
+		return fmt.Errorf("stat object %s: %w", object, err)
+	}
+
 	writeOp := rados.CreateWriteOp()
 	defer writeOp.Release()
 
@@ -691,9 +699,6 @@ func createRadosObject(w http.ResponseWriter, r *http.Request, ioctx *rados.IOCo
 
 	err = writeOp.Operate(ioctx, object, rados.OperationNoFlag)
 	if err != nil {
-		if errors.Is(err, rados.ErrObjectExists) {
-			return errObjectExists
-		}
 		return fmt.Errorf("write object %s: %w", object, err)
 	}
 

--- a/testdata/blob-overwrite-forbidden.txtar
+++ b/testdata/blob-overwrite-forbidden.txtar
@@ -1,0 +1,36 @@
+exec restic-ceph-server --socket $WORK/restic.sock &server&
+exec bash wait-for-socket.sh
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localhost/?create=true'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --data-binary @blob-data-original http://localhost/data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c
+cmp stdout blob-post-original.txt
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request POST --data-binary @blob-data-original http://localhost/data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c --output /dev/null
+stdout '403'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request POST --data-binary @blob-data-new http://localhost/data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c --output /dev/null
+stdout '400'
+
+kill server
+
+-- blob-data-original --
+foo
+-- blob-data-new --
+bar
+
+-- wait-for-socket.sh --
+set -o errexit
+set -o pipefail
+
+for i in {1..30}; do
+  if [ -S "$WORK/restic.sock" ]; then
+    exit 0
+  fi
+  sleep 0.1
+done
+
+echo "Socket did not appear in time" >&2
+exit 1
+
+-- blob-post-original.txt --

--- a/testdata/config-overwrite-forbidden.txtar
+++ b/testdata/config-overwrite-forbidden.txtar
@@ -1,0 +1,32 @@
+exec restic-ceph-server --socket $WORK/restic.sock &server&
+exec bash wait-for-socket.sh
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localhost/?create=true'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data-original http://localhost/config
+cmp stdout config-post-original.txt
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data-new http://localhost/config --output /dev/null
+stdout '403'
+
+kill server
+
+-- wait-for-socket.sh --
+set -o errexit
+set -o pipefail
+
+for i in {1..30}; do
+  if [ -S "$WORK/restic.sock" ]; then
+    exit 0
+  fi
+  sleep 0.1
+done
+
+echo "Socket did not appear in time" >&2
+exit 1
+
+-- config-data-original --
+{"version":2,"id":"original","chunker_polynomial":"original_polynomial"}
+-- config-post-original.txt --
+-- config-data-new --
+{"version":2,"id":"new","chunker_polynomial":"new_polynomial"}


### PR DESCRIPTION
Add pre-write validation in createRadosObject to check if objects already exist before attempting to write. This prevents accidental overwrites of both config files and data blobs.

Includes test coverage for:
- Blob overwrite prevention (same content and hash mismatches)
- Config overwrite prevention