### PR TITLE
Add test for invalid blob type and ID input validation

### DIFF
--- a/testdata/socket-invalid-blob-guards.txtar
+++ b/testdata/socket-invalid-blob-guards.txtar
@@ -1,0 +1,38 @@
+exec restic-ceph-server --socket $WORK/restic.sock &server&
+exec wait4unix $WORK/restic.sock
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localhost/?create=true'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/invalid_type/' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/invalid_type/abc123' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request POST --data-binary @test-data 'http://localhost/invalid_type/abc123' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/invalid_type/abc123' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/data/not-a-hex-id' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/data/xyz!@#$%' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/keys/abc%20123' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/snapshots/' --output /dev/null
+stdout '200'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --data-binary @test-data 'http://localhost/data/f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/data/f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2' --output /dev/null
+stdout '200'
+
+kill server
+
+-- test-data --
+test


### PR DESCRIPTION
Tests that server rejects malformed requests with 404:
- Invalid blob types (invalid_type) for all HTTP methods
- Non-hexadecimal blob IDs
- Special characters in blob IDs (!@#$%)
- URL-encoded invalid characters (spaces)

Validates that server continues normal operation after receiving invalid requests. Prevents namespace pollution, path traversal, and injection attacks.