### PR TITLE
Add tests for config HEAD and blob operation edge cases

### DIFF
--- a/testdata/socket-config-head-missing.txtar
+++ b/testdata/socket-config-head-missing.txtar
@@ -1,0 +1,20 @@
+exec restic-ceph-server --socket $WORK/restic.sock &server&
+exec wait4unix $WORK/restic.sock
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localhost/?create=true'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --head 'http://localhost/config' --output /dev/null
+stdout '404'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/config' --output /dev/null
+stdout '404'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --data-binary @config-data 'http://localhost/config'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --head 'http://localhost/config' --output /dev/null
+stdout '200'
+
+kill server
+
+-- config-data --
+{"version":2,"id":"test","chunker_polynomial":"25b468838dcb75ea"}

--- a/testdata/socket-data.txtar
+++ b/testdata/socket-data.txtar
@@ -7,6 +7,7 @@ exec curl --silent --unix-socket $WORK/restic.sock --request POST --data-binary 
 
 exec curl --silent --unix-socket $WORK/restic.sock --head --include 'http://localhost/data/abd9a2bf47af3416b041796843b9f9a7a5e987356da7ccfc750816219f0a075a'
 stdout 'HTTP.* 200'
+stdout 'Content-Length: 18'
 
 exec curl --silent --unix-socket $WORK/restic.sock --request GET 'http://localhost/data/abd9a2bf47af3416b041796843b9f9a7a5e987356da7ccfc750816219f0a075a'
 cmp stdout blob-data
@@ -14,7 +15,11 @@ cmp stdout blob-data
 exec curl --silent --unix-socket $WORK/restic.sock --request GET 'http://localhost/data/'
 stdout 'abd9a2bf47af3416b041796843b9f9a7a5e987356da7ccfc750816219f0a075a'
 
-exec curl --silent --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/data/abd9a2bf47af3416b041796843b9f9a7a5e987356da7ccfc750816219f0a075a'
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/data/abd9a2bf47af3416b041796843b9f9a7a5e987356da7ccfc750816219f0a075a' --output /dev/null
+stdout '200'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/data/abd9a2bf47af3416b041796843b9f9a7a5e987356da7ccfc750816219f0a075a' --output /dev/null
+stdout '200'
 
 exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request GET 'http://localhost/data/abd9a2bf47af3416b041796843b9f9a7a5e987356da7ccfc750816219f0a075a' --output /dev/null
 stdout '404'


### PR DESCRIPTION
Adds socket-config-head-missing.txtar to validate 404 responses when requesting config on empty repository. Tests both HEAD and GET methods return 404 before config exists, then 200 after config is uploaded.

Enhances socket-data.txtar with:
- HEAD metadata validation: Confirms Content-Length header accuracy
- Delete idempotency: Validates repeated DELETE returns 200, followed by GET returning 404

Completes remaining test gaps from original REST API test plan.