### PR TITLE
Add overlay pool layers for live pool migration

### DIFF
--- a/config.go
+++ b/config.go
@@ -160,7 +160,7 @@ func (c *Config) loadFromArgs(args []string) (configFile string, showVersion boo
 	fs.StringVar(&logFile, "log-file", "", "path to log file (default: stderr)")
 	fs.StringVar(&keyringPath, "keyring", "", "path to Ceph keyring file")
 	fs.StringVar(&clientID, "id", "", "Ceph client ID (e.g., 'restic' for client.restic)")
-	fs.Var(&poolSpecs, "pool", "Pool specification: 'pool[/namespace][:types]' where types is '*' or comma-separated list (repeatable, or semicolon-separated)")
+	fs.Var(&poolSpecs, "pool", "Pool specification: 'pool[/namespace][//lowerpool[/namespace]][:types]' where types is '*' or comma-separated list (repeatable, or semicolon-separated)")
 	fs.StringVar(&cephConf, "ceph-conf", "", "path to ceph.conf file")
 	fs.BoolVar(&striper, "striper", true, "enable librados striper for large objects")
 	fs.Int64Var(&readBufferSize, "read-buffer-size", defaultReadBufferSize, "buffer size for reading objects in bytes")
@@ -409,6 +409,10 @@ func (c *Config) normalizeRepos() error {
 				return fmt.Errorf("repo %q: invalid pool configuration: %v", name, err)
 			}
 			repo.BlobPools = &pools
+		} else if repo.BlobPools != nil {
+			if err := repo.BlobPools.normalizeLayers(); err != nil {
+				return fmt.Errorf("repo %q: %v", name, err)
+			}
 		}
 
 		if repo.MaxObjectSize < 0 {
@@ -441,11 +445,20 @@ func (c *Config) validateTailscaleCapabilityListeners() {
 	}
 }
 
-type BlobPoolConfig struct {
+type LayerPoolConfig struct {
 	Pool          string `json:"pool"`
 	Namespace     string `json:"namespace,omitempty"`
 	Striped       *bool  `json:"striped,omitempty"`
 	MaxObjectSize *int64 `json:"max_object_size,omitempty"`
+}
+
+type BlobPoolConfig struct {
+	Pool          string           `json:"pool"`
+	Namespace     string           `json:"namespace,omitempty"`
+	Striped       *bool            `json:"striped,omitempty"`
+	MaxObjectSize *int64           `json:"max_object_size,omitempty"`
+	Upper         *LayerPoolConfig `json:"upper,omitempty"`
+	Lower         *LayerPoolConfig `json:"lower,omitempty"`
 }
 
 type ServerConfigPools struct {
@@ -469,6 +482,7 @@ type BlobPool struct {
 	Striped       bool
 	Alignment     uint64
 	MaxObjectSize int64
+	Lower         *BlobPool
 }
 
 func (p *ServerConfigPools) getPoolForType(bt BlobType) BlobPoolConfig {
@@ -490,17 +504,48 @@ func (p *ServerConfigPools) getPoolForType(bt BlobType) BlobPoolConfig {
 	}
 }
 
+func (p *ServerConfigPools) normalizeLayers() error {
+	fields := []*BlobPoolConfig{&p.Config, &p.Keys, &p.Locks, &p.Snapshots, &p.Data, &p.Index}
+	for i, bt := range AllBlobTypes {
+		bpc := fields[i]
+		if bpc.Upper == nil && bpc.Lower == nil {
+			continue
+		}
+		if bpc.Upper == nil {
+			return fmt.Errorf("blob type %q: lower layer requires an explicit upper layer", bt)
+		}
+		if bpc.Lower == nil {
+			return fmt.Errorf("blob type %q: upper layer requires a lower layer (use the flat pool form for a single layer)", bt)
+		}
+		if bpc.Pool != "" || bpc.Namespace != "" || bpc.Striped != nil || bpc.MaxObjectSize != nil {
+			return fmt.Errorf("blob type %q: cannot combine pool with upper/lower layers", bt)
+		}
+		if bpc.Upper.Pool == "" {
+			return fmt.Errorf("blob type %q: upper pool name cannot be empty", bt)
+		}
+		if bpc.Lower.Pool == "" {
+			return fmt.Errorf("blob type %q: lower pool name cannot be empty", bt)
+		}
+		if bpc.Upper.Pool == bpc.Lower.Pool && bpc.Upper.Namespace == bpc.Lower.Namespace {
+			return fmt.Errorf("blob type %q: lower layer must differ from upper layer", bt)
+		}
+
+		bpc.Pool = bpc.Upper.Pool
+		bpc.Namespace = bpc.Upper.Namespace
+		bpc.Striped = bpc.Upper.Striped
+		bpc.MaxObjectSize = bpc.Upper.MaxObjectSize
+		bpc.Upper = nil
+	}
+	return nil
+}
+
 func poolSpecsToPoolsConfig(specs []string) poolsConfig {
 	result := make(poolsConfig)
 	for _, spec := range specs {
-		poolName, namespace, types, err := parsePoolSpec(spec)
+		key, types, err := parsePoolSpec(spec)
 		if err != nil {
 			result[spec] = nil
 			continue
-		}
-		key := poolName
-		if namespace != "" {
-			key = poolName + "/" + namespace
 		}
 		result[key] = types
 	}
@@ -514,6 +559,35 @@ func splitPoolKey(key string) (pool, namespace string) {
 	return key, ""
 }
 
+func parsePoolKey(key string) (BlobPoolConfig, error) {
+	upperPart, lowerPart, hasLower := strings.Cut(key, "//")
+
+	poolName, namespace := splitPoolKey(upperPart)
+	if poolName == "" {
+		return BlobPoolConfig{}, fmt.Errorf("empty pool name in specification: %q", key)
+	}
+	if strings.HasPrefix(namespace, "/") {
+		return BlobPoolConfig{}, fmt.Errorf("namespace cannot start with '/' in specification: %q", key)
+	}
+	bpc := BlobPoolConfig{Pool: poolName, Namespace: namespace}
+
+	if hasLower {
+		lowerPool, lowerNamespace := splitPoolKey(lowerPart)
+		if lowerPool == "" {
+			return BlobPoolConfig{}, fmt.Errorf("empty lower pool name in specification: %q", key)
+		}
+		if strings.HasPrefix(lowerNamespace, "/") {
+			return BlobPoolConfig{}, fmt.Errorf("namespace cannot start with '/' in specification: %q", key)
+		}
+		if lowerPool == poolName && lowerNamespace == namespace {
+			return BlobPoolConfig{}, fmt.Errorf("lower layer must differ from upper layer in specification: %q", key)
+		}
+		bpc.Lower = &LayerPoolConfig{Pool: lowerPool, Namespace: lowerNamespace}
+	}
+
+	return bpc, nil
+}
+
 func parsePoolsConfig(pc poolsConfig) (ServerConfigPools, error) {
 	if len(pc) == 0 {
 		return ServerConfigPools{}, errors.New("no pool specifications provided")
@@ -523,12 +597,11 @@ func parsePoolsConfig(pc poolsConfig) (ServerConfigPools, error) {
 	var catchAll *BlobPoolConfig
 
 	for key, types := range pc {
-		poolName, namespace := splitPoolKey(key)
-		if poolName == "" {
-			return ServerConfigPools{}, fmt.Errorf("empty pool name in specification: %q", key)
+		bpc, err := parsePoolKey(key)
+		if err != nil {
+			return ServerConfigPools{}, err
 		}
-
-		bpc := BlobPoolConfig{Pool: poolName, Namespace: namespace}
+		poolName := bpc.Pool
 
 		if len(types) == 0 || types == nil {
 			return ServerConfigPools{}, fmt.Errorf("invalid pool specification: %q", key)
@@ -573,10 +646,10 @@ func parsePoolsConfig(pc poolsConfig) (ServerConfigPools, error) {
 	}, nil
 }
 
-func parsePoolSpec(spec string) (poolName, namespace string, types []string, err error) {
+func parsePoolSpec(spec string) (key string, types []string, err error) {
 	spec = strings.TrimSpace(spec)
 	if spec == "" {
-		return "", "", nil, errors.New("empty pool specification")
+		return "", nil, errors.New("empty pool specification")
 	}
 
 	colonIdx := strings.Index(spec, ":")
@@ -588,33 +661,33 @@ func parsePoolSpec(spec string) (poolName, namespace string, types []string, err
 	}
 
 	poolPart = strings.TrimSpace(poolPart)
-	if slashIdx := strings.Index(poolPart, "/"); slashIdx != -1 {
-		poolName = poolPart[:slashIdx]
-		namespace = poolPart[slashIdx+1:]
-		if poolName == "" {
-			return "", "", nil, fmt.Errorf("empty pool name in specification: %q", spec)
-		}
-		if namespace == "" {
-			return "", "", nil, fmt.Errorf("empty namespace in specification: %q", spec)
-		}
-	} else {
-		poolName = poolPart
-	}
 
-	if poolName == "" {
-		return "", "", nil, fmt.Errorf("empty pool name in specification: %q", spec)
+	upperPart, lowerPart, hasLower := strings.Cut(poolPart, "//")
+	if err := validatePoolLayer(upperPart, spec); err != nil {
+		return "", nil, err
+	}
+	if hasLower {
+		if lowerPart == "" {
+			return "", nil, fmt.Errorf("empty lower pool name in specification: %q", spec)
+		}
+		if err := validatePoolLayer(lowerPart, spec); err != nil {
+			return "", nil, err
+		}
+		if lowerPart == upperPart {
+			return "", nil, fmt.Errorf("lower layer must differ from upper layer in specification: %q", spec)
+		}
 	}
 
 	if colonIdx == -1 {
-		return poolName, namespace, []string{"*"}, nil
+		return poolPart, []string{"*"}, nil
 	}
 
 	if typesPart == "" {
-		return "", "", nil, fmt.Errorf("empty types list in specification: %q", spec)
+		return "", nil, fmt.Errorf("empty types list in specification: %q", spec)
 	}
 
 	if typesPart == "*" {
-		return poolName, namespace, []string{"*"}, nil
+		return poolPart, []string{"*"}, nil
 	}
 
 	for _, t := range strings.Split(typesPart, ",") {
@@ -626,10 +699,24 @@ func parsePoolSpec(spec string) (poolName, namespace string, types []string, err
 	}
 
 	if len(types) == 0 {
-		return "", "", nil, fmt.Errorf("no valid types in specification: %q", spec)
+		return "", nil, fmt.Errorf("no valid types in specification: %q", spec)
 	}
 
-	return poolName, namespace, types, nil
+	return poolPart, types, nil
+}
+
+func validatePoolLayer(layer, spec string) error {
+	poolName, namespace := splitPoolKey(layer)
+	if poolName == "" {
+		return fmt.Errorf("empty pool name in specification: %q", spec)
+	}
+	if strings.Contains(layer, "/") && namespace == "" {
+		return fmt.Errorf("empty namespace in specification: %q", spec)
+	}
+	if strings.HasPrefix(namespace, "/") {
+		return fmt.Errorf("namespace cannot start with '/' in specification: %q", spec)
+	}
+	return nil
 }
 
 func isValidBlobTypeForMapping(bt BlobType) bool {

--- a/config_test.go
+++ b/config_test.go
@@ -546,6 +546,9 @@ func TestLoadConfigPoolErrors(t *testing.T) {
 		{"unknown blob type", []string{"--pool", "my-pool:badtype"}},
 		{"duplicate type across pools", []string{"--pool", "pool1:data;pool2:data"}},
 		{"multiple catch-all pools", []string{"--pool", "pool1;pool2"}},
+		{"empty lower pool", []string{"--pool", "new-pool//:data"}},
+		{"lower same as upper", []string{"--pool", "pool1//pool1"}},
+		{"namespace starting with slash", []string{"--pool", "pool1//pool2//pool3"}},
 	}
 
 	for _, tt := range tests {
@@ -738,6 +741,151 @@ func TestLoadConfigPoolSpecNamespaceErrors(t *testing.T) {
 	}
 }
 
+func TestLoadConfigPoolSpecLower(t *testing.T) {
+	config, _, err := loadConfig([]string{
+		"--pool", "new-data/a//old-data/b:data",
+		"--pool", "new-meta//old-meta:*",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := config.Repos["default"]
+	if def == nil || def.BlobPools == nil {
+		t.Fatal("expected default repo BlobPools")
+	}
+	if def.BlobPools.Data.Pool != "new-data" || def.BlobPools.Data.Namespace != "a" {
+		t.Errorf("expected Data = new-data/a, got %s/%s", def.BlobPools.Data.Pool, def.BlobPools.Data.Namespace)
+	}
+	if def.BlobPools.Data.Lower == nil || def.BlobPools.Data.Lower.Pool != "old-data" || def.BlobPools.Data.Lower.Namespace != "b" {
+		t.Fatalf("expected Data lower = old-data/b, got %+v", def.BlobPools.Data.Lower)
+	}
+	if def.BlobPools.Config.Pool != "new-meta" {
+		t.Errorf("expected Config pool = new-meta, got %s", def.BlobPools.Config.Pool)
+	}
+	if def.BlobPools.Config.Lower == nil || def.BlobPools.Config.Lower.Pool != "old-meta" {
+		t.Fatalf("expected Config lower = old-meta (catch-all propagation), got %+v", def.BlobPools.Config.Lower)
+	}
+	if def.BlobPools.Keys.Lower == nil || def.BlobPools.Keys.Lower.Pool != "old-meta" {
+		t.Fatalf("expected Keys lower = old-meta (catch-all propagation), got %+v", def.BlobPools.Keys.Lower)
+	}
+}
+
+func TestLoadConfigEnvPoolLower(t *testing.T) {
+	t.Setenv("RESTIC_RADOS_SERVER_POOL", "new-pool//old-pool:data;meta-pool:*")
+
+	config, _, err := loadConfig(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := config.Repos["default"]
+	if def == nil || def.BlobPools == nil {
+		t.Fatal("expected default repo BlobPools")
+	}
+	if def.BlobPools.Data.Pool != "new-pool" {
+		t.Errorf("expected Data pool = new-pool, got %s", def.BlobPools.Data.Pool)
+	}
+	if def.BlobPools.Data.Lower == nil || def.BlobPools.Data.Lower.Pool != "old-pool" {
+		t.Fatalf("expected Data lower = old-pool, got %+v", def.BlobPools.Data.Lower)
+	}
+	if def.BlobPools.Config.Lower != nil {
+		t.Errorf("expected Config lower unset, got %+v", def.BlobPools.Config.Lower)
+	}
+}
+
+func TestLoadConfigBlobPoolsLayered(t *testing.T) {
+	json := `{
+		"repos": {
+			"default": {
+				"blob_pools": {
+					"config": {"pool": "meta-pool"},
+					"keys": {"pool": "meta-pool"},
+					"locks": {"pool": "meta-pool"},
+					"snapshots": {"pool": "meta-pool"},
+					"index": {"pool": "meta-pool"},
+					"data": {
+						"upper": {"pool": "new-data", "namespace": "ns", "striped": true},
+						"lower": {"pool": "old-data", "namespace": "old", "striped": false, "max_object_size": 4194304}
+					}
+				}
+			}
+		}
+	}`
+	path := writeTemp(t, json)
+
+	config, _, err := loadConfig([]string{"--config", path})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	def := config.Repos["default"]
+	if def == nil || def.BlobPools == nil {
+		t.Fatal("expected default repo BlobPools")
+	}
+	data := def.BlobPools.Data
+	if data.Pool != "new-data" || data.Namespace != "ns" {
+		t.Errorf("expected upper folded into Data = new-data/ns, got %s/%s", data.Pool, data.Namespace)
+	}
+	if data.Striped == nil || *data.Striped != true {
+		t.Error("expected upper striped folded into Data")
+	}
+	if data.Upper != nil {
+		t.Error("expected Upper cleared after normalization")
+	}
+	if data.Lower == nil || data.Lower.Pool != "old-data" || data.Lower.Namespace != "old" {
+		t.Fatalf("expected Data lower = old-data/old, got %+v", data.Lower)
+	}
+	if data.Lower.Striped == nil || *data.Lower.Striped != false {
+		t.Error("expected lower striped override preserved")
+	}
+	if data.Lower.MaxObjectSize == nil || *data.Lower.MaxObjectSize != 4194304 {
+		t.Error("expected lower max_object_size override preserved")
+	}
+	if def.BlobPools.Config.Lower != nil {
+		t.Errorf("expected Config lower unset, got %+v", def.BlobPools.Config.Lower)
+	}
+}
+
+func TestLoadConfigBlobPoolsLayerValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		data string
+	}{
+		{"pool combined with layers", `{"pool": "x", "upper": {"pool": "a"}, "lower": {"pool": "b"}}`},
+		{"lower without upper", `{"pool": "x", "lower": {"pool": "b"}}`},
+		{"upper without lower", `{"upper": {"pool": "a"}}`},
+		{"empty upper pool", `{"upper": {"pool": ""}, "lower": {"pool": "b"}}`},
+		{"empty lower pool", `{"upper": {"pool": "a"}, "lower": {"pool": ""}}`},
+		{"identical layers", `{"upper": {"pool": "a", "namespace": "n"}, "lower": {"pool": "a", "namespace": "n"}}`},
+		{"unknown field in layer", `{"upper": {"pool": "a", "lower": {"pool": "c"}}, "lower": {"pool": "b"}}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			json := `{
+				"repos": {
+					"default": {
+						"blob_pools": {
+							"config": {"pool": "meta-pool"},
+							"keys": {"pool": "meta-pool"},
+							"locks": {"pool": "meta-pool"},
+							"snapshots": {"pool": "meta-pool"},
+							"index": {"pool": "meta-pool"},
+							"data": ` + tt.data + `
+						}
+					}
+				}
+			}`
+			path := writeTemp(t, json)
+			_, _, err := loadConfig([]string{"--config", path})
+			if err == nil {
+				t.Fatal("expected layer validation error")
+			}
+		})
+	}
+}
+
 func TestLoadConfigBlobPoolsJSON(t *testing.T) {
 	json := `{
 		"repos": {
@@ -898,6 +1046,16 @@ func TestPoolSpecsToPoolsConfig(t *testing.T) {
 			[]string{"data-pool:data,index", "meta-pool:*"},
 			poolsConfig{"data-pool": {"data", "index"}, "meta-pool": {"*"}},
 		},
+		{
+			"lower layer",
+			[]string{"new-pool//old-pool"},
+			poolsConfig{"new-pool//old-pool": {"*"}},
+		},
+		{
+			"lower layer with namespaces",
+			[]string{"new-pool/n1//old-pool/n2:data"},
+			poolsConfig{"new-pool/n1//old-pool/n2": {"data"}},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1023,6 +1181,64 @@ func TestParsePoolsConfig(t *testing.T) {
 		_, err := parsePoolsConfig(pc)
 		if err == nil {
 			t.Fatal("expected error for empty pool name")
+		}
+	})
+
+	t.Run("lower layer", func(t *testing.T) {
+		pc := poolsConfig{"new-pool//old-pool": {"*"}}
+		pools, err := parsePoolsConfig(pc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pools.Data.Pool != "new-pool" {
+			t.Errorf("expected Data pool = new-pool, got %s", pools.Data.Pool)
+		}
+		if pools.Data.Lower == nil || pools.Data.Lower.Pool != "old-pool" {
+			t.Fatalf("expected Data lower pool = old-pool, got %+v", pools.Data.Lower)
+		}
+		if pools.Data.Lower.Namespace != "" {
+			t.Errorf("expected empty lower namespace, got %s", pools.Data.Lower.Namespace)
+		}
+	})
+
+	t.Run("lower layer with namespaces", func(t *testing.T) {
+		pc := poolsConfig{"new-pool/n1//old-pool/n2": {"data"}}
+		pools, err := parsePoolsConfig(pc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pools.Data.Pool != "new-pool" || pools.Data.Namespace != "n1" {
+			t.Errorf("expected Data = new-pool/n1, got %s/%s", pools.Data.Pool, pools.Data.Namespace)
+		}
+		if pools.Data.Lower == nil || pools.Data.Lower.Pool != "old-pool" || pools.Data.Lower.Namespace != "n2" {
+			t.Fatalf("expected Data lower = old-pool/n2, got %+v", pools.Data.Lower)
+		}
+	})
+
+	t.Run("same pool different namespaces", func(t *testing.T) {
+		pc := poolsConfig{"my-pool/new//my-pool/old": {"*"}}
+		pools, err := parsePoolsConfig(pc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if pools.Data.Namespace != "new" || pools.Data.Lower.Namespace != "old" {
+			t.Errorf("expected namespaces new/old, got %s/%s", pools.Data.Namespace, pools.Data.Lower.Namespace)
+		}
+	})
+
+	t.Run("empty lower pool name", func(t *testing.T) {
+		pc := poolsConfig{"new-pool//": {"*"}}
+		_, err := parsePoolsConfig(pc)
+		if err == nil {
+			t.Fatal("expected error for empty lower pool name")
+		}
+	})
+
+	t.Run("identical layers", func(t *testing.T) {
+		pc := poolsConfig{"my-pool/ns//my-pool/ns": {"*"}}
+		_, err := parsePoolsConfig(pc)
+		if err == nil {
+			t.Fatal("expected error for identical layers")
 		}
 	})
 }

--- a/connection_manager.go
+++ b/connection_manager.go
@@ -163,7 +163,7 @@ func (cm *ConnectionManager) connect() error {
 	return nil
 }
 
-func (cm *ConnectionManager) getIOContextForPool(poolName string, radosCalls *uint64) (*rados.IOContext, error) {
+func (cm *ConnectionManager) getIOContextsForBlobPool(bp *BlobPool, radosCalls *uint64) (*rados.IOContext, *rados.IOContext, error) {
 	const maxAttempts = 2
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		cm.mu.RLock()
@@ -172,7 +172,7 @@ func (cm *ConnectionManager) getIOContextForPool(poolName string, radosCalls *ui
 
 		if conn == nil {
 			if err := cm.tryReconnect(); err != nil {
-				return nil, errConnectionUnavailable
+				return nil, nil, errConnectionUnavailable
 			}
 
 			cm.mu.RLock()
@@ -180,33 +180,57 @@ func (cm *ConnectionManager) getIOContextForPool(poolName string, radosCalls *ui
 			cm.mu.RUnlock()
 
 			if conn == nil {
-				return nil, errConnectionUnavailable
+				return nil, nil, errConnectionUnavailable
 			}
 		}
 
 		atomic.AddUint64(radosCalls, 1)
-		slog.Debug("rados.OpenIOContext", "pool", poolName)
-		ioctx, err := conn.OpenIOContext(poolName)
+		slog.Debug("rados.OpenIOContext", "pool", bp.Pool)
+		ioctx, err := conn.OpenIOContext(bp.Pool)
 		if err != nil {
 			if errors.Is(err, rados.ErrNotFound) {
-				return nil, err
+				return nil, nil, err
 			}
 
-			slog.Error("failed to open IO context", "pool", poolName, "error", err, "attempt", attempt+1)
+			slog.Error("failed to open IO context", "pool", bp.Pool, "error", err, "attempt", attempt+1)
 			cm.markConnectionBroken()
 			if attempt < maxAttempts-1 {
 				if err := cm.tryReconnect(); err != nil {
-					return nil, errConnectionUnavailable
+					return nil, nil, errConnectionUnavailable
 				}
 				continue
 			}
-			return nil, errConnectionUnavailable
+			return nil, nil, errConnectionUnavailable
 		}
 
-		return ioctx, nil
+		if bp.Lower == nil {
+			return ioctx, nil, nil
+		}
+
+		atomic.AddUint64(radosCalls, 1)
+		slog.Debug("rados.OpenIOContext", "pool", bp.Lower.Pool)
+		lowerIoctx, err := conn.OpenIOContext(bp.Lower.Pool)
+		if err != nil {
+			ioctx.Destroy()
+			if errors.Is(err, rados.ErrNotFound) {
+				return nil, nil, fmt.Errorf("%w: lower pool %q not found", errConnectionUnavailable, bp.Lower.Pool)
+			}
+
+			slog.Error("failed to open IO context", "pool", bp.Lower.Pool, "error", err, "attempt", attempt+1)
+			cm.markConnectionBroken()
+			if attempt < maxAttempts-1 {
+				if err := cm.tryReconnect(); err != nil {
+					return nil, nil, errConnectionUnavailable
+				}
+				continue
+			}
+			return nil, nil, errConnectionUnavailable
+		}
+
+		return ioctx, lowerIoctx, nil
 	}
 
-	return nil, errConnectionUnavailable
+	return nil, nil, errConnectionUnavailable
 }
 
 func (cm *ConnectionManager) GetBlobPoolForRepo(repo string, bt BlobType) (*BlobPool, error) {
@@ -227,7 +251,7 @@ func (cm *ConnectionManager) GetBlobPoolForRepo(repo string, bt BlobType) (*Blob
 	return bp, nil
 }
 
-func (cm *ConnectionManager) GetIOContextForRepo(repo string, blobType BlobType) (*rados.IOContext, *BlobPool, error) {
+func (cm *ConnectionManager) GetIOContextForRepo(repo string, blobType BlobType) (*rados.IOContext, *rados.IOContext, *BlobPool, error) {
 	var radosCalls uint64
 	defer func() {
 		slog.Debug("GetIOContextForRepo", "repo", repo, "blob_type", blobType, "rados_calls", atomic.LoadUint64(&radosCalls))
@@ -235,19 +259,23 @@ func (cm *ConnectionManager) GetIOContextForRepo(repo string, blobType BlobType)
 
 	bp, err := cm.GetBlobPoolForRepo(repo, blobType)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	ioctx, err := cm.getIOContextForPool(bp.Pool, &radosCalls)
+	ioctx, lowerIoctx, err := cm.getIOContextsForBlobPool(bp, &radosCalls)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	if bp.Namespace != "" {
 		ioctx.SetNamespace(bp.Namespace)
 	}
 
-	return ioctx, bp, nil
+	if lowerIoctx != nil && bp.Lower.Namespace != "" {
+		lowerIoctx.SetNamespace(bp.Lower.Namespace)
+	}
+
+	return ioctx, lowerIoctx, bp, nil
 }
 
 func (cm *ConnectionManager) InitializeAllPoolConfigs(repos map[string]*RepoConfig) error {
@@ -265,8 +293,12 @@ func (cm *ConnectionManager) InitializeAllPoolConfigs(repos map[string]*RepoConf
 			continue
 		}
 		for _, bt := range AllBlobTypes {
-			if p := repo.BlobPools.getPoolForType(bt).Pool; p != "" {
-				allPools[p] = struct{}{}
+			bpc := repo.BlobPools.getPoolForType(bt)
+			if bpc.Pool != "" {
+				allPools[bpc.Pool] = struct{}{}
+			}
+			if bpc.Lower != nil && bpc.Lower.Pool != "" {
+				allPools[bpc.Lower.Pool] = struct{}{}
 			}
 		}
 	}
@@ -293,10 +325,14 @@ func (cm *ConnectionManager) InitializeAllPoolConfigs(repos map[string]*RepoConf
 	}
 
 	type blobPoolKey struct {
-		pool          string
-		namespace     string
-		striped       bool
-		maxObjectSize int64
+		pool               string
+		namespace          string
+		striped            bool
+		maxObjectSize      int64
+		lowerPool          string
+		lowerNS            string
+		lowerStriped       bool
+		lowerMaxObjectSize int64
 	}
 
 	repoBlobPools := make(map[string]map[BlobType]*BlobPool)
@@ -344,6 +380,29 @@ func (cm *ConnectionManager) InitializeAllPoolConfigs(repos map[string]*RepoConf
 			}
 
 			key := blobPoolKey{pool: bpc.Pool, namespace: bpc.Namespace, striped: striped, maxObjectSize: maxObjSize}
+			if bpc.Lower != nil {
+				lowerStriped := striped
+				if bpc.Lower.Striped != nil {
+					lowerStriped = *bpc.Lower.Striped
+				}
+				lowerMaxObjSize := maxObjSize
+				if bpc.Lower.MaxObjectSize != nil {
+					if *bpc.Lower.MaxObjectSize > cm.maxObjectSize {
+						slog.Warn("lower pool max_object_size exceeds cluster limit, clamping",
+							"repo", repoName,
+							"blob_type", bt,
+							"configured", *bpc.Lower.MaxObjectSize,
+							"limit", cm.maxObjectSize)
+						lowerMaxObjSize = cm.maxObjectSize
+					} else {
+						lowerMaxObjSize = *bpc.Lower.MaxObjectSize
+					}
+				}
+				key.lowerPool = bpc.Lower.Pool
+				key.lowerNS = bpc.Lower.Namespace
+				key.lowerStriped = lowerStriped
+				key.lowerMaxObjectSize = lowerMaxObjSize
+			}
 			bp, ok := dedup[key]
 			if !ok {
 				bp = &BlobPool{
@@ -352,6 +411,15 @@ func (cm *ConnectionManager) InitializeAllPoolConfigs(repos map[string]*RepoConf
 					Striped:       striped,
 					Alignment:     poolAlignments[bpc.Pool],
 					MaxObjectSize: maxObjSize,
+				}
+				if bpc.Lower != nil {
+					bp.Lower = &BlobPool{
+						Pool:          bpc.Lower.Pool,
+						Namespace:     bpc.Lower.Namespace,
+						Striped:       key.lowerStriped,
+						Alignment:     poolAlignments[bpc.Lower.Pool],
+						MaxObjectSize: key.lowerMaxObjectSize,
+					}
 				}
 				dedup[key] = bp
 			}

--- a/handlers.go
+++ b/handlers.go
@@ -47,6 +47,9 @@ type HandlerContext struct {
 	ioctx           *rados.IOContext
 	radosIO         RadosIOContext
 	striperIO       RadosIOContext
+	lowerIoctx      *rados.IOContext
+	lowerRadosIO    RadosIOContext
+	lowerStriperIO  RadosIOContext
 	maxObjectSize   int64
 	radosCalls      uint64
 	readBufferPool  *BufferPool
@@ -79,6 +82,9 @@ type httpRange struct {
 
 func (hctx *HandlerContext) Destroy() {
 	hctx.ioctx.Destroy()
+	if hctx.lowerIoctx != nil {
+		hctx.lowerIoctx.Destroy()
+	}
 	if hctx.readBufPtr != nil {
 		hctx.readBufferPool.Put(hctx.readBufPtr)
 	}
@@ -87,21 +93,59 @@ func (hctx *HandlerContext) Destroy() {
 	}
 }
 
-func (hctx *HandlerContext) statRadosObject(object string) (RadosIOContext, StatInfo, error) {
-	if hctx.striperIO != nil {
-		stat, err := hctx.radosIO.Stat(object)
+func statInLayer(plainIO, striperIO RadosIOContext, object string) (RadosIOContext, StatInfo, error) {
+	if striperIO != nil {
+		stat, err := plainIO.Stat(object)
 		if !errors.Is(err, rados.ErrNotFound) {
-			return hctx.radosIO, stat, err
+			return plainIO, stat, err
 		}
-		_, stripeErr := hctx.radosIO.Stat(object + firstStripeSuffix)
+		_, stripeErr := plainIO.Stat(object + firstStripeSuffix)
 		if !errors.Is(stripeErr, rados.ErrNotFound) {
-			stat, err = hctx.striperIO.Stat(object)
-			return hctx.striperIO, stat, err
+			stat, err = striperIO.Stat(object)
+			return striperIO, stat, err
 		}
-		return hctx.radosIO, StatInfo{}, err
+		return plainIO, StatInfo{}, err
 	}
-	stat, err := hctx.radosIO.Stat(object)
-	return hctx.radosIO, stat, err
+	stat, err := plainIO.Stat(object)
+	return plainIO, stat, err
+}
+
+func (hctx *HandlerContext) statRadosObject(object string) (RadosIOContext, StatInfo, error) {
+	rioctx, stat, err := statInLayer(hctx.radosIO, hctx.striperIO, object)
+	if errors.Is(err, rados.ErrNotFound) && hctx.lowerRadosIO != nil {
+		return statInLayer(hctx.lowerRadosIO, hctx.lowerStriperIO, object)
+	}
+	return rioctx, stat, err
+}
+
+func (hctx *HandlerContext) removeRadosObject(object string, canStripe bool) error {
+	type layer struct {
+		plainIO   RadosIOContext
+		striperIO RadosIOContext
+	}
+	var layers []layer
+	if hctx.lowerRadosIO != nil {
+		layers = append(layers, layer{hctx.lowerRadosIO, hctx.lowerStriperIO})
+	}
+	layers = append(layers, layer{hctx.radosIO, hctx.striperIO})
+
+	for _, l := range layers {
+		striperIO := l.striperIO
+		if !canStripe {
+			striperIO = nil
+		}
+		rioctx, _, err := statInLayer(l.plainIO, striperIO, object)
+		if errors.Is(err, rados.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("stat object %s: %w", object, err)
+		}
+		if err := rioctx.Remove(object); err != nil {
+			return fmt.Errorf("delete object %s: %w", object, err)
+		}
+	}
+	return nil
 }
 
 func (rw *responseWriter) WriteHeader(code int) {
@@ -140,7 +184,7 @@ func (h *Handler) logRequest(method, path string, status int, duration time.Dura
 }
 
 func (h *Handler) openIOContext(ctx context.Context, blobType BlobType) (*HandlerContext, error) {
-	ioctx, bp, err := h.connMgr.GetIOContextForRepo(h.repo, blobType)
+	ioctx, lowerIoctx, bp, err := h.connMgr.GetIOContextForRepo(h.repo, blobType)
 	if err != nil {
 		return nil, err
 	}
@@ -150,6 +194,7 @@ func (h *Handler) openIOContext(ctx context.Context, blobType BlobType) (*Handle
 
 	hctx := &HandlerContext{
 		ioctx:           ioctx,
+		lowerIoctx:      lowerIoctx,
 		maxObjectSize:   bp.MaxObjectSize,
 		readBufferPool:  h.readBufferPool,
 		readBufPtr:      readBufPtr,
@@ -161,6 +206,13 @@ func (h *Handler) openIOContext(ctx context.Context, blobType BlobType) (*Handle
 
 	if bp.Striped {
 		hctx.striperIO = NewStripedIO(ioctx, uint64(bp.MaxObjectSize), bp.Alignment, *readBufPtr, *writeBufPtr, &hctx.radosCalls)
+	}
+
+	if lowerIoctx != nil {
+		hctx.lowerRadosIO = NewRadosIO(lowerIoctx, bp.Lower.Alignment, *readBufPtr, *writeBufPtr, &hctx.radosCalls)
+		if bp.Lower.Striped {
+			hctx.lowerStriperIO = NewStripedIO(lowerIoctx, uint64(bp.Lower.MaxObjectSize), bp.Lower.Alignment, *readBufPtr, *writeBufPtr, &hctx.radosCalls)
+		}
 	}
 
 	return hctx, nil
@@ -309,18 +361,8 @@ func (h *Handler) deleteConfig(w http.ResponseWriter, r *http.Request) {
 		hctx.Destroy()
 	}()
 
-	_, err := hctx.radosIO.Stat(configObjectName)
-	if errors.Is(err, rados.ErrNotFound) {
-		rw.WriteHeader(http.StatusOK)
-		return
-	}
-	if err != nil {
-		h.handleRadosError(rw, r, configObjectName, fmt.Errorf("stat object %s: %w", configObjectName, err))
-		return
-	}
-
-	if err := hctx.radosIO.Remove(configObjectName); err != nil {
-		h.handleRadosError(rw, r, configObjectName, fmt.Errorf("delete object %s: %w", configObjectName, err))
+	if err := hctx.removeRadosObject(configObjectName, false); err != nil {
+		h.handleRadosError(rw, r, configObjectName, err)
 		return
 	}
 
@@ -373,68 +415,30 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request) {
 		hctx.Destroy()
 	}()
 
-	slog.Debug("rados.Iter")
-	hctx.radosCalls++
-	iter, err := hctx.ioctx.Iter()
-	if err != nil {
-		slog.Error("failed to list blobs", "type", blobType, "error", fmt.Errorf("create iterator: %w", err))
-		http.Error(rw, "internal server error", http.StatusInternalServerError)
-		return
-	}
-	defer iter.Close()
-
 	useV2 := acceptsBlobListV2(r)
 	prefix := blobType + "/"
 
 	blobNames := []string{}
 	blobInfos := []blobInfo{}
 
-	for iter.Next() {
-		objectName := iter.Value()
-		if objectName == "" || !strings.HasPrefix(objectName, prefix) {
-			continue
-		}
-
-		blobID := strings.TrimPrefix(objectName, prefix)
-
-		if stripedBlobIDRegex.MatchString(blobID) && !firstStripedBlobIDRegex.MatchString(blobID) {
-			continue
-		}
-
-		if firstStripedBlobIDRegex.MatchString(blobID) {
-			blobID = blobID[:len(blobID)-stripeSuffixLen]
-		}
-
-		if !hexBlobIDRegex.MatchString(blobID) {
-			slog.Warn("skipping unknown object", "object", objectName)
-			continue
-		}
-
-		baseObjectName := prefix + blobID
-
-		if useV2 {
-			_, stat, err := hctx.statRadosObject(baseObjectName)
-			if err != nil {
-				slog.Error("failed to list blobs", "type", blobType, "error", fmt.Errorf("stat %s: %w", baseObjectName, err))
-				http.Error(rw, "internal server error", http.StatusInternalServerError)
-				return
-			}
-			blobInfos = append(blobInfos, blobInfo{
-				Name: blobID,
-				Size: stat.Size,
-			})
-		} else {
-			blobNames = append(blobNames, blobID)
-		}
+	sources := []*rados.IOContext{hctx.ioctx}
+	var seen map[string]struct{}
+	if hctx.lowerIoctx != nil {
+		sources = append(sources, hctx.lowerIoctx)
+		seen = make(map[string]struct{})
 	}
 
-	if err := iter.Err(); err != nil {
-		slog.Error("failed to list blobs", "type", blobType, "error", fmt.Errorf("iterate objects: %w", err))
-		http.Error(rw, "internal server error", http.StatusInternalServerError)
-		return
+	for _, src := range sources {
+		err := hctx.collectBlobs(src, prefix, useV2, seen, &blobNames, &blobInfos)
+		if err != nil {
+			slog.Error("failed to list blobs", "type", blobType, "error", err)
+			http.Error(rw, "internal server error", http.StatusInternalServerError)
+			return
+		}
 	}
 
 	var data []byte
+	var err error
 	if useV2 {
 		data, err = json.Marshal(blobInfos)
 		if err != nil {
@@ -457,6 +461,66 @@ func (h *Handler) listBlobs(w http.ResponseWriter, r *http.Request) {
 	if _, err = rw.Write(data); err != nil {
 		slog.Warn("failed to list blobs", "type", blobType, "error", err)
 	}
+}
+
+func (hctx *HandlerContext) collectBlobs(src *rados.IOContext, prefix string, useV2 bool, seen map[string]struct{}, blobNames *[]string, blobInfos *[]blobInfo) error {
+	slog.Debug("rados.Iter")
+	hctx.radosCalls++
+	iter, err := src.Iter()
+	if err != nil {
+		return fmt.Errorf("create iterator: %w", err)
+	}
+	defer iter.Close()
+
+	for iter.Next() {
+		objectName := iter.Value()
+		if objectName == "" || !strings.HasPrefix(objectName, prefix) {
+			continue
+		}
+
+		blobID := strings.TrimPrefix(objectName, prefix)
+
+		if stripedBlobIDRegex.MatchString(blobID) && !firstStripedBlobIDRegex.MatchString(blobID) {
+			continue
+		}
+
+		if firstStripedBlobIDRegex.MatchString(blobID) {
+			blobID = blobID[:len(blobID)-stripeSuffixLen]
+		}
+
+		if !hexBlobIDRegex.MatchString(blobID) {
+			slog.Warn("skipping unknown object", "object", objectName)
+			continue
+		}
+
+		if seen != nil {
+			if _, ok := seen[blobID]; ok {
+				continue
+			}
+			seen[blobID] = struct{}{}
+		}
+
+		baseObjectName := prefix + blobID
+
+		if useV2 {
+			_, stat, err := hctx.statRadosObject(baseObjectName)
+			if err != nil {
+				return fmt.Errorf("stat %s: %w", baseObjectName, err)
+			}
+			*blobInfos = append(*blobInfos, blobInfo{
+				Name: blobID,
+				Size: stat.Size,
+			})
+		} else {
+			*blobNames = append(*blobNames, blobID)
+		}
+	}
+
+	if err := iter.Err(); err != nil {
+		return fmt.Errorf("iterate objects: %w", err)
+	}
+
+	return nil
 }
 
 func (h *Handler) getBlob(w http.ResponseWriter, r *http.Request) {
@@ -574,18 +638,8 @@ func (h *Handler) deleteBlob(w http.ResponseWriter, r *http.Request) {
 
 	objectName := blobType + "/" + blobID
 
-	rioctx, _, err := hctx.statRadosObject(objectName)
-	if errors.Is(err, rados.ErrNotFound) {
-		rw.WriteHeader(http.StatusOK)
-		return
-	}
-	if err != nil {
-		h.handleRadosError(rw, r, blobID, fmt.Errorf("stat object %s: %w", objectName, err))
-		return
-	}
-
-	if err := rioctx.Remove(objectName); err != nil {
-		h.handleRadosError(rw, r, blobID, fmt.Errorf("delete object %s: %w", objectName, err))
+	if err := hctx.removeRadosObject(objectName, true); err != nil {
+		h.handleRadosError(rw, r, blobID, err)
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
@@ -782,7 +836,8 @@ func (hctx *HandlerContext) serveRadosObject(w http.ResponseWriter, r *http.Requ
 		return fmt.Errorf("stat %s: %w", object, err)
 	}
 
-	striped := hctx.striperIO != nil && rioctx == hctx.striperIO
+	striped := (hctx.striperIO != nil && rioctx == hctx.striperIO) ||
+		(hctx.lowerStriperIO != nil && rioctx == hctx.lowerStriperIO)
 	slog.Debug("reading blob", "object", object, "size", stat.Size, "striped", striped)
 
 	if stat.Size > uint64(math.MaxInt64) {

--- a/testdata/overlay-delete-both.txtar
+++ b/testdata/overlay-delete-both.txtar
@@ -1,0 +1,45 @@
+tail-logs
+create-pool new
+create-pool old
+
+exec restic-rados-server --pool=$CEPH_POOL_OLD --listen $WORK/restic-old.sock &oldserver&
+wait4socket $WORK/restic-old.sock
+
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST 'http://localhost/?create=true'
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data http://localhost/config
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @blob-x 'http://localhost/data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @blob-z 'http://localhost/data/f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2'
+
+kill oldserver
+
+exec rados --pool $CEPH_POOL_NEW put data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c blob-x
+
+exec restic-rados-server --pool=$CEPH_POOL_NEW//$CEPH_POOL_OLD --listen $WORK/restic.sock &server&
+wait4socket $WORK/restic.sock
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c' --output /dev/null
+stdout '200'
+
+exec rados --pool $CEPH_POOL_NEW ls
+! stdout 'data/b5bb9d80'
+
+exec rados --pool $CEPH_POOL_OLD ls
+! stdout 'data/b5bb9d80'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c' --output /dev/null
+stdout '200'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/data/f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2' --output /dev/null
+stdout '200'
+
+exec rados --pool $CEPH_POOL_OLD ls
+! stdout 'data/'
+
+kill server
+
+-- config-data --
+{"version":2,"id":"test","chunker_polynomial":"25b468838dcb75ea"}
+-- blob-x --
+foo
+-- blob-z --
+test

--- a/testdata/overlay-list-merge.txtar
+++ b/testdata/overlay-list-merge.txtar
@@ -1,0 +1,46 @@
+tail-logs
+create-pool new
+create-pool old
+
+exec restic-rados-server --pool=$CEPH_POOL_OLD --listen $WORK/restic-old.sock &oldserver&
+wait4socket $WORK/restic-old.sock
+
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST 'http://localhost/?create=true'
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data http://localhost/config
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @blob-a 'http://localhost/data/b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @blob-c 'http://localhost/data/f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2'
+
+kill oldserver
+
+exec rados --pool $CEPH_POOL_NEW put data/f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2 blob-c-upper
+
+exec restic-rados-server --pool=$CEPH_POOL_NEW//$CEPH_POOL_OLD --listen $WORK/restic.sock &server&
+wait4socket $WORK/restic.sock
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @blob-b 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+
+exec curl --silent --unix-socket $WORK/restic.sock 'http://localhost/data/'
+stdout 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c'
+stdout 'a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+stdout 'f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2'
+! stdout 'f2ca1bb6.*f2ca1bb6'
+! stdout 'b5bb9d80.*b5bb9d80'
+! stdout 'a1fff0ff.*a1fff0ff'
+
+exec curl --silent --unix-socket $WORK/restic.sock --header 'Accept: application/vnd.x.restic.rest.v2' 'http://localhost/data/'
+stdout '"name":"f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2","size":20'
+stdout '"name":"b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c","size":4'
+stdout '"name":"a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae","size":13'
+
+kill server
+
+-- config-data --
+{"version":2,"id":"test","chunker_polynomial":"25b468838dcb75ea"}
+-- blob-a --
+foo
+-- blob-b --
+test content
+-- blob-c --
+test
+-- blob-c-upper --
+test content longer

--- a/testdata/overlay-namespace.txtar
+++ b/testdata/overlay-namespace.txtar
@@ -1,0 +1,34 @@
+tail-logs
+create-pool shared
+
+exec restic-rados-server --pool=$CEPH_POOL_SHARED/old --listen $WORK/restic-old.sock &oldserver&
+wait4socket $WORK/restic-old.sock
+
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST 'http://localhost/?create=true'
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data http://localhost/config
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @test-data 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+
+kill oldserver
+
+exec restic-rados-server --pool=$CEPH_POOL_SHARED/new//$CEPH_POOL_SHARED/old --listen $WORK/restic.sock &server&
+wait4socket $WORK/restic.sock
+
+exec curl --silent --unix-socket $WORK/restic.sock 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+cmp stdout test-data
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @new-data 'http://localhost/data/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
+
+exec rados --pool $CEPH_POOL_SHARED --namespace new ls
+stdout 'data/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
+
+exec rados --pool $CEPH_POOL_SHARED --namespace old ls
+! stdout 'data/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
+
+kill server
+
+-- config-data --
+{"version":2,"id":"test","chunker_polynomial":"25b468838dcb75ea"}
+-- test-data --
+test content
+-- new-data --
+bar

--- a/testdata/overlay-read-fallback.txtar
+++ b/testdata/overlay-read-fallback.txtar
@@ -1,0 +1,47 @@
+tail-logs
+create-pool new
+create-pool old
+
+exec restic-rados-server --pool=$CEPH_POOL_OLD --listen $WORK/restic-old.sock &oldserver&
+wait4socket $WORK/restic-old.sock
+
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST 'http://localhost/?create=true'
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data http://localhost/config
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @test-data 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+
+kill oldserver
+
+exec restic-rados-server --pool=$CEPH_POOL_NEW//$CEPH_POOL_OLD --listen $WORK/restic.sock &server&
+wait4socket $WORK/restic.sock
+
+exec curl --silent --unix-socket $WORK/restic.sock http://localhost/config
+cmp stdout config-data
+
+exec curl --silent --unix-socket $WORK/restic.sock 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+cmp stdout test-data
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --head 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae' --output /dev/null
+stdout '200'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @new-data 'http://localhost/data/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
+
+exec rados --pool $CEPH_POOL_NEW ls
+stdout 'data/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
+
+exec rados --pool $CEPH_POOL_OLD ls
+! stdout 'data/7d865e959b2466918c9863afca942d0fb89d7c9ac0c99bafc3749504ded97730'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request POST --data-binary @test-data 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae' --output /dev/null
+stdout '403'
+
+exec rados --pool $CEPH_POOL_NEW ls
+! stdout 'data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+
+kill server
+
+-- config-data --
+{"version":2,"id":"test","chunker_polynomial":"25b468838dcb75ea"}
+-- test-data --
+test content
+-- new-data --
+bar

--- a/testdata/overlay-striped-lower.txtar
+++ b/testdata/overlay-striped-lower.txtar
@@ -1,0 +1,47 @@
+tail-logs
+create-pool new
+create-pool old
+
+exec restic-rados-server --pool=$CEPH_POOL_OLD --max-object-size 1048576 --listen $WORK/restic-old.sock &oldserver&
+wait4socket $WORK/restic-old.sock
+
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST 'http://localhost/?create=true'
+exec curl --silent --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data http://localhost/config
+
+bin-file rand striped-blob 3670016
+sha256 striped-blob HASH
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic-old.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @striped-blob http://localhost/data/$HASH
+stdout '200'
+
+exec rados --pool $CEPH_POOL_OLD ls
+stdout 'data/'$HASH'\.0000000000000000'
+stdout 'data/'$HASH'\.0000000000000003'
+
+kill oldserver
+
+exec restic-rados-server --pool=$CEPH_POOL_NEW//$CEPH_POOL_OLD --max-object-size 1048576 --listen $WORK/restic.sock &server&
+wait4socket $WORK/restic.sock
+
+exec curl --silent --unix-socket $WORK/restic.sock http://localhost/data/$HASH --output downloaded
+bin-cmp downloaded striped-blob
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --range 1000000-2999999 http://localhost/data/$HASH --output range-part
+stdout '206'
+byte-count range-part
+stdout '2000000'
+
+exec curl --silent --unix-socket $WORK/restic.sock 'http://localhost/data/'
+stdout $HASH
+! stdout $HASH'\.'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE http://localhost/data/$HASH --output /dev/null
+stdout '200'
+
+exec rados --pool $CEPH_POOL_OLD ls
+! stdout 'data/'
+
+kill server
+
+-- config-data --
+{"version":2,"id":"test","chunker_polynomial":"25b468838dcb75ea"}

--- a/testdata/overlay-write-upper.txtar
+++ b/testdata/overlay-write-upper.txtar
@@ -1,0 +1,26 @@
+tail-logs
+create-pool new
+create-pool old
+
+exec restic-rados-server --pool=$CEPH_POOL_NEW//$CEPH_POOL_OLD --listen $WORK/restic.sock &server&
+wait4socket $WORK/restic.sock
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localhost/?create=true'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @config-data http://localhost/config
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @test-data 'http://localhost/data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+
+exec rados --pool $CEPH_POOL_NEW ls
+stdout '^config$'
+stdout 'data/a1fff0ffefb9eace7230c24e50731f0a91c62f9cefdfe77121c2f607125dffae'
+
+exec rados --pool $CEPH_POOL_OLD ls
+! stdout '.'
+
+kill server
+
+-- config-data --
+{"version":2,"id":"test","chunker_polynomial":"25b468838dcb75ea"}
+-- test-data --
+test content


### PR DESCRIPTION
Writes always go to the upper pool while the lower pool serves as a read fallback until a pool migration completes.