### PR TITLE
Reject non-positive max_object_size and guard striper against zero ob…

### DIFF
--- a/config.go
+++ b/config.go
@@ -536,6 +536,16 @@ func (p *ServerConfigPools) normalizeLayers() error {
 		bpc.MaxObjectSize = bpc.Upper.MaxObjectSize
 		bpc.Upper = nil
 	}
+
+	for i, bt := range AllBlobTypes {
+		bpc := fields[i]
+		if bpc.MaxObjectSize != nil && *bpc.MaxObjectSize <= 0 {
+			return fmt.Errorf("blob type %q: max_object_size must be positive, got %d", bt, *bpc.MaxObjectSize)
+		}
+		if bpc.Lower != nil && bpc.Lower.MaxObjectSize != nil && *bpc.Lower.MaxObjectSize <= 0 {
+			return fmt.Errorf("blob type %q: lower layer max_object_size must be positive, got %d", bt, *bpc.Lower.MaxObjectSize)
+		}
+	}
 	return nil
 }
 

--- a/config_test.go
+++ b/config_test.go
@@ -859,6 +859,9 @@ func TestLoadConfigBlobPoolsLayerValidation(t *testing.T) {
 		{"empty lower pool", `{"upper": {"pool": "a"}, "lower": {"pool": ""}}`},
 		{"identical layers", `{"upper": {"pool": "a", "namespace": "n"}, "lower": {"pool": "a", "namespace": "n"}}`},
 		{"unknown field in layer", `{"upper": {"pool": "a", "lower": {"pool": "c"}}, "lower": {"pool": "b"}}`},
+		{"zero max_object_size", `{"pool": "a", "max_object_size": 0}`},
+		{"negative max_object_size", `{"pool": "a", "max_object_size": -1}`},
+		{"zero lower max_object_size", `{"upper": {"pool": "a"}, "lower": {"pool": "b", "max_object_size": 0}}`},
 	}
 
 	for _, tt := range tests {

--- a/rados.go
+++ b/rados.go
@@ -82,6 +82,11 @@ func NewStripedIO(ioctx *rados.IOContext, objectSize uint64, alignment uint64, r
 	}
 	if alignment > 1 {
 		objectSize = objectSize / alignment * alignment
+		if objectSize == 0 {
+			slog.Warn("object size smaller than pool alignment, clamping to one alignment unit",
+				"alignment", alignment)
+			objectSize = alignment
+		}
 		if aligned := len(writeBuf) / int(alignment) * int(alignment); aligned > 0 {
 			slog.Debug("NewStripedIO writeBuf aligned", "from", len(writeBuf), "to", aligned, "alignment", alignment)
 			writeBuf = writeBuf[:aligned]


### PR DESCRIPTION
…ject size

A max_object_size of 0 in blob_pools passed validation and a small max_object_size on a high-alignment pool trimmed to 0, both causing an integer divide-by-zero panic on every striped object operation.