### PR TITLE
Fix HTTP range handling edge cases

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -22,10 +22,11 @@ import (
 const configObjectName = "config"
 
 var (
-	errObjectNotFound = errors.New("object not found")
-	errObjectExists   = errors.New("object exists")
-	errHashMismatch   = errors.New("hash mismatch")
-	errClientAborted  = errors.New("client aborted request")
+	errObjectNotFound      = errors.New("object not found")
+	errObjectExists        = errors.New("object exists")
+	errHashMismatch        = errors.New("hash mismatch")
+	errClientAborted       = errors.New("client aborted request")
+	errRangeNotSatisfiable = errors.New("requested range not satisfiable")
 )
 
 var (
@@ -285,6 +286,8 @@ func (h *Handler) handleRadosError(w http.ResponseWriter, r *http.Request, objec
 		http.Error(w, "ceph cluster unavailable", http.StatusServiceUnavailable)
 	case errors.Is(err, errObjectNotFound):
 		http.NotFound(w, r)
+	case errors.Is(err, errRangeNotSatisfiable):
+		http.Error(w, "requested range not satisfiable", http.StatusRequestedRangeNotSatisfiable)
 	case errors.Is(err, errObjectExists):
 		http.Error(w, "object already exists", http.StatusForbidden)
 	case errors.Is(err, errHashMismatch):
@@ -750,7 +753,7 @@ func parseExpectedHash(object string) ([32]byte, error) {
 
 func parseRange(r *http.Request, size int64) (*httpRange, error) {
 	if size == 0 {
-		return &httpRange{start: 0, end: 0, status: http.StatusOK}, nil
+		return &httpRange{start: 0, end: -1, status: http.StatusOK}, nil
 	}
 
 	if r == nil {
@@ -787,6 +790,9 @@ func parseRange(r *http.Request, size int64) (*httpRange, error) {
 		suffixLength, err := strconv.ParseInt(parts[1], 10, 64)
 		if err != nil || suffixLength < 0 {
 			return nil, fmt.Errorf("invalid suffix length in range: %s", rangeHeader)
+		}
+		if suffixLength == 0 {
+			return nil, fmt.Errorf("zero-length suffix range: %s", rangeHeader)
 		}
 		if suffixLength >= size {
 			start = 0
@@ -846,8 +852,7 @@ func (hctx *HandlerContext) serveRadosObject(w http.ResponseWriter, r *http.Requ
 
 	rng, err := parseRange(r, int64(stat.Size))
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusRequestedRangeNotSatisfiable)
-		return err
+		return fmt.Errorf("%w: %v", errRangeNotSatisfiable, err)
 	}
 
 	if rng.status == http.StatusPartialContent {

--- a/testdata/range-edge-cases.txtar
+++ b/testdata/range-edge-cases.txtar
@@ -1,0 +1,38 @@
+tail-logs
+create-pool
+
+exec restic-rados-server --listen $WORK/restic.sock &server&
+wait4socket $WORK/restic.sock
+exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localhost/?create=true'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --data-binary @empty http://localhost/config
+
+exec curl --silent --include --unix-socket $WORK/restic.sock http://localhost/config
+stdout 'HTTP/.* 200'
+stdout 'Content-Length: 0'
+
+exec curl --silent --write-out 'STATUS=%{http_code} LEN=%{size_download}' --unix-socket $WORK/restic.sock http://localhost/config --output /dev/null
+stdout 'STATUS=200 LEN=0'
+
+exec curl --silent --head --write-out 'STATUS=%{http_code}' --unix-socket $WORK/restic.sock http://localhost/config --output /dev/null
+stdout 'STATUS=200'
+
+bin-file rand blob 1000
+sha256 blob HASH
+exec curl --silent --unix-socket $WORK/restic.sock --request POST --data-binary @blob http://localhost/data/$HASH
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --header 'Range: bytes=-0' http://localhost/data/$HASH --output /dev/null
+stdout '416'
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --header 'Range: bytes=99999-' http://localhost/data/$HASH --output oob-body
+stdout '416'
+! grep 'internal server error' oob-body
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --header 'Range: bytes=0-99' http://localhost/data/$HASH --output range-body
+stdout '206'
+byte-count range-body
+stdout '100'
+
+kill server
+
+-- empty --


### PR DESCRIPTION
Empty objects were served with Content-Length: 1, a range-parse failure wrote a 416 and then let the caller append a second 500 body, and a zero-length suffix range (bytes=-0) returned 206 with an invalid Content-Range instead of 416.