### PR TITLE
Validate repo names for route-pattern safety

### DIFF
--- a/config.go
+++ b/config.go
@@ -10,10 +10,13 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
 )
+
+var validRepoNameRegex = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
 
 type BlobType string
 
@@ -385,6 +388,9 @@ func isReservedRepoName(name string) bool {
 
 func (c *Config) normalizeRepos() error {
 	for name, repo := range c.Repos {
+		if !validRepoNameRegex.MatchString(name) {
+			return fmt.Errorf("invalid repo name %q (must contain only letters, digits, '.', '_', or '-')", name)
+		}
 		if name != "default" && isReservedRepoName(name) {
 			return fmt.Errorf("reserved repo name %q (conflicts with blob type)", name)
 		}

--- a/config_test.go
+++ b/config_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 )
@@ -633,6 +634,20 @@ func TestLoadConfigReservedRepoName(t *testing.T) {
 			_, _, err := loadConfig([]string{"--config", path})
 			if err == nil {
 				t.Fatalf("expected error for reserved repo name %q", name)
+			}
+		})
+	}
+}
+
+func TestLoadConfigInvalidRepoName(t *testing.T) {
+	invalid := []string{"my repo", "", "a/b", "{x}", "repo\ttab"}
+	for _, name := range invalid {
+		t.Run(name, func(t *testing.T) {
+			json := `{"repos": {` + strconv.Quote(name) + `: {"pools": {"my-pool": ["*"]}}}}`
+			path := writeTemp(t, json)
+			_, _, err := loadConfig([]string{"--config", path})
+			if err == nil {
+				t.Fatalf("expected error for invalid repo name %q", name)
 			}
 		})
 	}


### PR DESCRIPTION
Repo names were used directly as ServeMux path patterns, so a name containing a space panicked at startup and an empty or brace-containing name registered an unreachable or overly broad route; names are now restricted to a safe character set.