### PR TITLE
Reject duplicate pool keys in --pool specifications

### DIFF
--- a/config.go
+++ b/config.go
@@ -547,7 +547,7 @@ func poolSpecsToPoolsConfig(specs []string) poolsConfig {
 			result[spec] = nil
 			continue
 		}
-		result[key] = types
+		result[key] = append(result[key], types...)
 	}
 	return result
 }

--- a/config_test.go
+++ b/config_test.go
@@ -1047,6 +1047,11 @@ func TestPoolSpecsToPoolsConfig(t *testing.T) {
 			poolsConfig{"data-pool": {"data", "index"}, "meta-pool": {"*"}},
 		},
 		{
+			"repeated pool merges types",
+			[]string{"bulk:data", "bulk:index"},
+			poolsConfig{"bulk": {"data", "index"}},
+		},
+		{
 			"lower layer",
 			[]string{"new-pool//old-pool"},
 			poolsConfig{"new-pool//old-pool": {"*"}},


### PR DESCRIPTION
poolSpecsToPoolsConfig folded specs into a map keyed by pool, so repeating the same pool across --pool flags silently overwrote earlier blob-type assignments, sending data to the wrong pool or failing at runtime instead of erroring at startup.