### PR TITLE
Ignore tailscale_capability in stdio mode

### DIFF
--- a/main.go
+++ b/main.go
@@ -103,9 +103,6 @@ func main() {
 	readPool := NewBufferPool(config.ReadBufferSize)
 	writePool := NewBufferPool(config.WriteBufferSize)
 
-	mux := http.NewServeMux()
-	setupAllRoutes(mux, connMgr, config.Repos, config.TailscaleCapability, readPool, writePool)
-
 	ctx := context.Background()
 
 	ctx, cancel := signal.NotifyContext(ctx, syscall.SIGINT, syscall.SIGTERM)
@@ -129,6 +126,14 @@ func main() {
 	}
 
 	config.validateTailscaleCapabilityListeners()
+
+	tailscaleCapability := config.TailscaleCapability
+	if config.Stdio {
+		tailscaleCapability = ""
+	}
+
+	mux := http.NewServeMux()
+	setupAllRoutes(mux, connMgr, config.Repos, tailscaleCapability, readPool, writePool)
 
 	if config.Stdio && time.Duration(config.MaxIdleTime) > 0 {
 		slog.Error("--max-idle-time is not supported in stdio mode")

--- a/testdata/stdio-tailscale-capability-ignored.txtar
+++ b/testdata/stdio-tailscale-capability-ignored.txtar
@@ -1,0 +1,14 @@
+tail-logs
+create-pool
+
+env RESTIC_RADOS_SERVER_CONFIG=$WORK/cfg.json
+
+exec restic init --option rclone.program=restic-rados-server --repo rclone: --password-file $WORK/password.txt
+
+exec restic cat config --option rclone.program=restic-rados-server --repo rclone: --password-file $WORK/password.txt
+stdout '"version"'
+
+-- cfg.json --
+{"tailscale_capability": "example.com/cap"}
+-- password.txt --
+secret


### PR DESCRIPTION
The capability was stored on every handler before stdio mode was decided, so in stdio mode (where no Tailscale proxy sets the header) the config warning claimed headers were ignored while every request was actually denied, and a client-supplied header was still honored.