### PR TITLE
Stop stdio mode from hanging on SIGINT/SIGTERM

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -215,6 +215,15 @@ func (cfg listenerConfig) Serve(ctx context.Context, handler http.Handler, shutd
 			stdin:  os.Stdin,
 			stdout: os.Stdout,
 		}
+		done := make(chan struct{})
+		defer close(done)
+		go func() {
+			select {
+			case <-ctx.Done():
+				_ = stdioConn.Close()
+			case <-done:
+			}
+		}()
 		server.ServeConn(stdioConn, &http2.ServeConnOpts{
 			Context: ctx,
 			Handler: handler,


### PR DESCRIPTION
http2.ServeConn does not observe context cancellation, so stdio mode never returned on a signal and could only be killed with SIGKILL; the connection is now closed when the context is done to unblock the serve loop.