### PR TITLE
Enforce exclusive object creation on concurrent writes

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -912,6 +912,9 @@ func (hctx *HandlerContext) createRadosObject(w http.ResponseWriter, r *http.Req
 
 	_, sum, err := rioctx.WriteObject(object, r.Body)
 	if err != nil {
+		if errors.Is(err, errObjectExists) {
+			return errObjectExists
+		}
 		if rmErr := rioctx.Remove(object); rmErr != nil && !errors.Is(rmErr, rados.ErrNotFound) {
 			slog.Error("failed to clean up object after write error; a truncated object may remain",
 				"object", object, "write_error", err, "cleanup_error", rmErr)

--- a/rados.go
+++ b/rados.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -340,7 +341,10 @@ func (r *radosIOContextWrapper) WriteObject(object string, rd io.Reader) (n int6
 	slog.Debug("rados.CreateWriteOp", "object", object)
 	atomic.AddUint64(r.radosCalls, 1)
 	err = op.Operate(r.ioctx, object, rados.OperationNoFlag)
-	if err != nil && err != rados.ErrObjectExists {
+	if err != nil {
+		if errors.Is(err, rados.ErrObjectExists) {
+			return 0, [32]byte{}, errObjectExists
+		}
 		return 0, [32]byte{}, fmt.Errorf("create object: %w", err)
 	}
 
@@ -407,7 +411,10 @@ func (s *striperIOContextWrapper) WriteObject(object string, rd io.Reader) (n in
 	slog.Debug("rados.CreateWriteOp", "object", firstObjID)
 	atomic.AddUint64(s.radosCalls, 1)
 	err = op.Operate(s.ioctx, firstObjID, rados.OperationNoFlag)
-	if err != nil && err != rados.ErrObjectExists {
+	if err != nil {
+		if errors.Is(err, rados.ErrObjectExists) {
+			return 0, [32]byte{}, errObjectExists
+		}
 		return 0, [32]byte{}, fmt.Errorf("create object: %w", err)
 	}
 


### PR DESCRIPTION
The create-exclusive guard was ineffective: go-ceph wraps the EEXIST errno in an OperationError, so the 'err != rados.ErrObjectExists' comparison never matched and WriteObject swallowed the conflict, letting two concurrent POSTs of the same object interleave appends into one corrupt object that both acknowledged with 200.