### PR TITLE
Derive striper geometry from stored xattrs instead of live config

### DIFF
--- a/rados.go
+++ b/rados.go
@@ -107,6 +107,24 @@ func (s *striperIOContextWrapper) getObjectID(soid string, objectno uint64) stri
 	return fmt.Sprintf("%s"+stripeSuffixFormat, soid, objectno)
 }
 
+func (s *striperIOContextWrapper) stripeObjectSize(firstObjID string) (uint64, error) {
+	attr := make([]byte, 32)
+	slog.Debug("rados.GetXattr", "object", firstObjID, "xattr", xattrObjectSize)
+	atomic.AddUint64(s.radosCalls, 1)
+	n, err := s.ioctx.GetXattr(firstObjID, xattrObjectSize, attr)
+	if err != nil {
+		return 0, fmt.Errorf("get object_size xattr: %w", err)
+	}
+	size, err := strconv.ParseUint(string(attr[:n]), 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("parse object_size xattr: %w", err)
+	}
+	if size == 0 {
+		return 0, fmt.Errorf("invalid object_size xattr: 0")
+	}
+	return size, nil
+}
+
 func (r *radosIOContextWrapper) Stat(object string) (StatInfo, error) {
 	slog.Debug("rados.Stat", "object", object)
 	atomic.AddUint64(r.radosCalls, 1)
@@ -270,6 +288,11 @@ func (s *striperIOContextWrapper) ReadObject(object string, offset, length int64
 		return 0, [32]byte{}, fmt.Errorf("parse size xattr: %w", err)
 	}
 
+	objectSize, err := s.stripeObjectSize(firstObjID)
+	if err != nil {
+		return 0, [32]byte{}, err
+	}
+
 	if uint64(offset) >= totalSize {
 		return 0, [32]byte{}, nil
 	}
@@ -288,10 +311,10 @@ func (s *striperIOContextWrapper) ReadObject(object string, offset, length int64
 	remaining := int64(readLen)
 
 	for remaining > 0 {
-		objectNo := currentOffset / s.objectSize
-		objectOffset := currentOffset % s.objectSize
+		objectNo := currentOffset / objectSize
+		objectOffset := currentOffset % objectSize
 
-		availableInObject := s.objectSize - objectOffset
+		availableInObject := objectSize - objectOffset
 		toRead := remaining
 		if uint64(toRead) > availableInObject {
 			toRead = int64(availableInObject)

--- a/testdata/striper-geometry-change.txtar
+++ b/testdata/striper-geometry-change.txtar
@@ -1,0 +1,52 @@
+tail-logs
+create-pool
+
+exec restic-rados-server --listen $WORK/restic.sock --max-object-size 4194304 &server&
+wait4socket $WORK/restic.sock
+exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localhost/?create=true'
+
+bin-file rand large-blob 10485760
+sha256 large-blob HASH
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request POST --header 'Content-Type: application/octet-stream' --data-binary @large-blob http://localhost/data/$HASH
+stdout '200'
+
+exec rados --pool $RESTIC_RADOS_SERVER_POOL ls
+stdout 'data/'$HASH'\.0000000000000000'
+stdout 'data/'$HASH'\.0000000000000002'
+
+kill server
+
+exec restic-rados-server --listen $WORK/restic2.sock --max-object-size 2097152 &server2&
+wait4socket $WORK/restic2.sock
+
+exec curl --silent --unix-socket $WORK/restic2.sock --head --include http://localhost/data/$HASH
+stdout 'HTTP/.* 200'
+stdout 'Content-Length: 10485760'
+
+exec curl --silent --unix-socket $WORK/restic2.sock http://localhost/data/$HASH --output full-download
+bin-cmp full-download large-blob
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic2.sock --header 'Range: bytes=2097152-4194303' http://localhost/data/$HASH --output range-download
+stdout '206'
+byte-count range-download
+stdout '2097152'
+
+exec dd if=large-blob of=correct-slice bs=1048576 skip=2 count=2
+bin-cmp range-download correct-slice
+
+kill server2
+
+exec restic-rados-server --listen $WORK/restic3.sock --max-object-size 8388608 &server3&
+wait4socket $WORK/restic3.sock
+
+exec curl --silent --unix-socket $WORK/restic3.sock http://localhost/data/$HASH --output full-download-large
+bin-cmp full-download-large large-blob
+
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic3.sock --request DELETE http://localhost/data/$HASH --output /dev/null
+stdout '200'
+
+exec rados --pool $RESTIC_RADOS_SERVER_POOL ls
+! stdout 'data/'
+
+kill server3


### PR DESCRIPTION
The striper read and remove paths computed stripe boundaries from the current configured object size rather than the striper.layout.object_size recorded when the object was written, so changing the effective object size (cluster osd_max_object_size or repo/pool max_object_size) silently corrupted or truncated existing striped objects.