### PR TITLE
Skip unsupported striped layouts in v2 listings

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -487,6 +487,10 @@ func (hctx *HandlerContext) collectBlobs(src *rados.IOContext, prefix string, us
 
 		if useV2 {
 			_, stat, err := hctx.statRadosObject(baseObjectName)
+			if errors.Is(err, errUnsupportedStriperLayout) {
+				slog.Warn("skipping striped object with unsupported layout", "object", baseObjectName, "error", err)
+				continue
+			}
 			if err != nil {
 				return fmt.Errorf("stat %s: %w", baseObjectName, err)
 			}

--- a/rados.go
+++ b/rados.go
@@ -24,6 +24,8 @@ const (
 	firstStripeSuffix  = ".0000000000000000"
 )
 
+var errUnsupportedStriperLayout = errors.New("unsupported striper layout")
+
 type RadosIOContext interface {
 	Stat(object string) (StatInfo, error)
 	Remove(object string) error
@@ -128,7 +130,7 @@ func (s *striperIOContextWrapper) stripeObjectSize(firstObjID string) (uint64, e
 		return 0, err
 	}
 	if size == 0 {
-		return 0, fmt.Errorf("invalid object_size xattr: 0")
+		return 0, fmt.Errorf("%w: object_size=0", errUnsupportedStriperLayout)
 	}
 	unit, err := s.getXattrUint(firstObjID, xattrStripeUnit)
 	if err != nil {
@@ -139,7 +141,7 @@ func (s *striperIOContextWrapper) stripeObjectSize(firstObjID string) (uint64, e
 		return 0, err
 	}
 	if count != 1 || unit != size {
-		return 0, fmt.Errorf("unsupported striper layout: stripe_count=%d stripe_unit=%d object_size=%d", count, unit, size)
+		return 0, fmt.Errorf("%w: stripe_count=%d stripe_unit=%d object_size=%d", errUnsupportedStriperLayout, count, unit, size)
 	}
 	return size, nil
 }

--- a/testdata/striper-foreign-layout.txtar
+++ b/testdata/striper-foreign-layout.txtar
@@ -16,6 +16,12 @@ exec curl --silent --unix-socket $WORK/restic.sock --request POST 'http://localh
 exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --head 'http://localhost/data/0000000000000000000000000000000000000000000000000000000000000001' --output /dev/null
 stdout '500'
 
+exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --header 'Accept: application/vnd.x.restic.rest.v2' 'http://localhost/data/' --output list.json
+stdout '200'
+grep '0000000000000000000000000000000000000000000000000000000000000002' list.json
+! grep '0000000000000000000000000000000000000000000000000000000000000001' list.json
+wait4log 'skipping striped object with unsupported layout' $RESTIC_RADOS_SERVER_LOG_FILE
+
 exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic.sock --request DELETE 'http://localhost/data/0000000000000000000000000000000000000000000000000000000000000001' --output /dev/null
 stdout '500'
 


### PR DESCRIPTION
A single foreign striped object with a restic-shaped name previously failed the whole listing with a 500, blocking backup, check, and prune for the entire repo.