### PR TITLE
Validate blob types in single-type pool specs

### DIFF
--- a/config.go
+++ b/config.go
@@ -655,14 +655,15 @@ func poolSpecsToPoolsConfig(specs []string) (poolsConfig, error) {
 		if err != nil {
 			return nil, err
 		}
-		if len(types) > 1 {
-			for _, t := range types {
-				if t == "*" {
+		for _, t := range types {
+			if t == "*" {
+				if len(types) > 1 {
 					return nil, fmt.Errorf("pool %q: wildcard '*' cannot be mixed with explicit types", key)
 				}
-				if !isValidBlobTypeForMapping(BlobType(t)) {
-					return nil, fmt.Errorf("pool %q: unknown blob type %q", key, t)
-				}
+				continue
+			}
+			if !isValidBlobTypeForMapping(BlobType(t)) {
+				return nil, fmt.Errorf("pool %q: unknown blob type %q", key, t)
 			}
 		}
 		for _, t := range types {

--- a/testdata/pool-spec-duplicates.txtar
+++ b/testdata/pool-spec-duplicates.txtar
@@ -32,3 +32,9 @@ exec curl --silent --write-out '%{http_code}' --unix-socket $WORK/restic4.sock '
 stdout '200'
 
 kill server4
+
+! exec restic-rados-server --pool $RESTIC_RADOS_SERVER_POOL':datta' --pool $RESTIC_RADOS_SERVER_POOL':*' --listen $WORK/restic5.sock
+stderr 'unknown blob type "datta"'
+
+! exec restic-rados-server --pool $RESTIC_RADOS_SERVER_POOL':*' --pool $RESTIC_RADOS_SERVER_POOL':datta' --listen $WORK/restic6.sock
+stderr 'unknown blob type "datta"'


### PR DESCRIPTION
A wildcard spec for the same pool previously collapsed away an invalid type before validation could reject it, so typos like --pool mypool:datta started the server silently.