### PR TITLE
Add testscript for blob upload hash-mismatch cleanup (direct and striped writes)

### DIFF
--- a/testdata/blob-upload-hash-mismatch.txtar
+++ b/testdata/blob-upload-hash-mismatch.txtar
@@ -1,0 +1,34 @@
+tail-logs
+create-pool
+
+exec restic-rados-server --listen 127.0.0.1:$PORT --max-object-size 1048576 &server&
+wait4socket 127.0.0.1:$PORT
+
+exec curl --silent --request POST 'http://127.0.0.1:'$PORT'/?create=true'
+
+exec curl --silent --write-out '\n%{http_code}\n' --request POST --header 'Content-Type: application/octet-stream' --data-binary @small-payload 'http://127.0.0.1:'$PORT'/data/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+stdout 'hash mismatch'
+stdout '400'
+
+exec curl --silent --write-out '%{http_code}' --output /dev/null 'http://127.0.0.1:'$PORT'/data/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+stdout '404'
+
+exec rados --pool $RESTIC_RADOS_SERVER_POOL ls
+! stdout 'data/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+bin-file rand striped-payload 2097152
+exec curl --silent --write-out '\n%{http_code}\n' --request POST --header 'Content-Type: application/octet-stream' --data-binary @striped-payload 'http://127.0.0.1:'$PORT'/data/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+stdout 'hash mismatch'
+stdout '400'
+
+exec curl --silent --write-out '%{http_code}' --output /dev/null 'http://127.0.0.1:'$PORT'/data/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+stdout '404'
+
+exec rados --pool $RESTIC_RADOS_SERVER_POOL ls
+! stdout 'data/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+! stdout 'data/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+
+kill server
+
+-- small-payload --
+content whose hash does not match the requested blob ID


### PR DESCRIPTION
### Motivation

- Add an end-to-end test to ensure the server correctly rejects uploads whose requested blob ID does not match the uploaded content SHA-256 and cleans up any partial objects.

### Description

- Add `testdata/blob-upload-hash-mismatch.txtar` which starts the server with a reduced `--max-object-size` (1 MiB) and creates a repository via the usual testscript conventions.
- Test a direct write to a valid 64-character blob ID containing non-matching content and assert the server responds with HTTP 400 containing `hash mismatch` and subsequent GETs return HTTP 404, and no logical RADOS object remains in the configured pool.
- Test a striped write by uploading a payload larger than `max-object-size` to exercise the striped-write cleanup path and assert the same HTTP and RADOS-pool cleanup behaviour.
- Keep generated data small by using a 2 MiB striped payload and a 1 MiB `max-object-size` to force the striped code path without large artifacts.

### Testing

- Ran `git diff --check`, which reported no issues.
- Attempted to run the testscript with `go test -v -timeout 10m -run '^TestScript/blob-upload-hash-mismatch$' ./...`, but the build failed in this environment because the Ceph development header `rados/librados.h` is not available, so the automated test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e1dda6c048326b50dc5d09c3c25e5)