### PR TITLE
Expand blob list Accept negotiation coverage

### DIFF
--- a/testdata/socket-list-accept-negotiation.txtar
+++ b/testdata/socket-list-accept-negotiation.txtar
@@ -23,8 +23,30 @@ stdout '"size":17'
 
 exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: text/html, application/vnd.x.restic.rest.v2, */*' --include 'http://localhost/data/'
 stdout 'Content-Type: application/vnd.x.restic.rest.v2'
-stdout '"name":'
-stdout '"size":'
+stdout '"name":"f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"'
+stdout '"size":5'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0' --include 'http://localhost/data/'
+stdout 'Content-Type: application/vnd.x.restic.rest.v1'
+stdout '\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0, application/json' --include 'http://localhost/data/'
+stdout 'Content-Type: application/vnd.x.restic.rest.v1'
+stdout '\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0' --header 'Accept: application/vnd.x.restic.rest.v2' --include 'http://localhost/data/'
+stdout 'Content-Type: application/vnd.x.restic.rest.v2'
+stdout '"name":"f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"'
+stdout '"size":5'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0;broken, application/vnd.x.restic.rest.v2;=broken' --include 'http://localhost/data/'
+stdout 'Content-Type: application/vnd.x.restic.rest.v1'
+stdout '\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]'
+
+exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: Application/Vnd.X.Restic.Rest.V2' --include 'http://localhost/data/'
+stdout 'Content-Type: application/vnd.x.restic.rest.v2'
+stdout '"name":"40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702"'
+stdout '"size":17'
 
 kill server
 

--- a/testdata/socket-list-accept-negotiation.txtar
+++ b/testdata/socket-list-accept-negotiation.txtar
@@ -28,11 +28,11 @@ stdout '"size":5'
 
 exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0' --include 'http://localhost/data/'
 stdout 'Content-Type: application/vnd.x.restic.rest.v1'
-stdout '\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]'
+stdout '(\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]|\["f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2","40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702"\])'
 
 exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0, application/json' --include 'http://localhost/data/'
 stdout 'Content-Type: application/vnd.x.restic.rest.v1'
-stdout '\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]'
+stdout '(\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]|\["f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2","40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702"\])'
 
 exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0' --header 'Accept: application/vnd.x.restic.rest.v2' --include 'http://localhost/data/'
 stdout 'Content-Type: application/vnd.x.restic.rest.v2'
@@ -41,7 +41,7 @@ stdout '"size":5'
 
 exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: application/vnd.x.restic.rest.v2;q=0;broken, application/vnd.x.restic.rest.v2;=broken' --include 'http://localhost/data/'
 stdout 'Content-Type: application/vnd.x.restic.rest.v1'
-stdout '\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]'
+stdout '(\["40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702","f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2"\]|\["f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2","40b89de5ed0336c2ce8958fa5eb483bd74c9757643bab14451b8d6fa064f4702"\])'
 
 exec curl --silent --unix-socket $WORK/restic.sock --request GET --header 'Accept: Application/Vnd.X.Restic.Rest.V2' --include 'http://localhost/data/'
 stdout 'Content-Type: application/vnd.x.restic.rest.v2'


### PR DESCRIPTION
### Motivation

- Increase test coverage for HTTP Accept negotiation on the blob list endpoint to ensure disabled or malformed v2 media ranges do not cause incorrect schema selection or server errors.
- Verify behavior for mixed media ranges, repeated `Accept` fields, malformed parameters, and case-insensitive media-type parsing so the server selects the correct response schema and content type.

### Description

- Extended `testdata/socket-list-accept-negotiation.txtar` with new `curl` requests that exercise `Accept: application/vnd.x.restic.rest.v2;q=0`, mixed media ranges with an additional acceptable type, repeated `Accept` header fields where a later field enables v2, malformed v2 parameters, and a mixed-case media type.
- Strengthened the existing multi-range test to assert concrete `name` and `size` fields so schema checks cannot pass based only on HTTP 200.
- For each new case, added assertions for both the `Content-Type` header and schema-specific response fields to prevent false positives.

### Testing

- `git diff --check` was executed and produced no problems.
- Attempted to run the testscript for `TestScript/socket-list-accept-negotiation` with `go test -run '^TestScript/socket-list-accept-negotiation$' -v -count=1`, but the build failed in this environment due to a missing Ceph development header (`rados/librados.h`), so the test could not complete here.
- The modified testdata file was committed locally after the changes were applied.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e1de572b48326bba64b5e350ad205)