### PR TITLE
Secure Helm ingress by default

### DIFF
--- a/charts/restic-rados-server/templates/networkpolicy.yaml
+++ b/charts/restic-rados-server/templates/networkpolicy.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "restic-rados-server.fullname" . }}
+  labels:
+    {{- include "restic-rados-server.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "restic-rados-server.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+{{- end }}

--- a/charts/restic-rados-server/values.yaml
+++ b/charts/restic-rados-server/values.yaml
@@ -51,6 +51,10 @@ service:
   type: ClusterIP
   port: 8000
 
+networkPolicy:
+  enabled: true
+  ingress: []
+
 serviceAccount:
   create: true
   name: ""


### PR DESCRIPTION
### Motivation

- The chart shipped a `ClusterIP` Service and left `config.repos` and `config.tailscale_capability` unset, effectively exposing an unauthenticated read-write REST API to any pod that can reach the Service.  
- Hardening the chart by default reduces the risk of accidental cluster-internal access to repository write/delete operations.  
- Make the change minimally invasive so operators can still opt into explicit ingress peers or disable the policy.

### Description

- Add a new `networkPolicy` values block to `charts/restic-rados-server/values.yaml` with `enabled: true` and `ingress: []` so the policy is on by default but configurable.  
- Add `charts/restic-rados-server/templates/networkpolicy.yaml` which renders a `NetworkPolicy` that selects the server pods and applies the user-provided `.Values.networkPolicy.ingress` rules when `networkPolicy.enabled` is true.  
- Preserve the existing `Service` and application config; no changes were made to server authorization logic or Service behavior.

### Testing

- Ran formatting check with `gofmt -l .` which reported no files (passed).  
- Ran lightweight repository checks with `git diff --check` which returned no whitespace errors (passed).  
- Attempted `go test -v -timeout 10m ./...` which could not complete due to missing Ceph development headers in the environment (blocked).  
- Attempted `helm lint` / `helm template` but the Helm download in the environment returned HTTP 403 so chart template validation could not complete (blocked).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e27c92b608326bffcb2c7f9bbd69a)